### PR TITLE
Add Email and Name to Note requests

### DIFF
--- a/Sources/StampKit/SKNoteDescription.swift
+++ b/Sources/StampKit/SKNoteDescription.swift
@@ -17,11 +17,15 @@ public struct SKNoteDescription {
     public let code: SKResponseStatusCode
     public let text: String
     public let colour: SKNoteColour
+    public let email: String?
+    public let name: String?
     
-    public init(text: String, colour: SKNoteColour, code: SKResponseStatusCode) {
+    public init(text: String, colour: SKNoteColour, code: SKResponseStatusCode, email: String? = nil, name: String? = nil) {
         self.text = text
         self.colour = colour
         self.code = code
+        self.email = email
+        self.name = name
     }
     
 }
@@ -29,7 +33,7 @@ public struct SKNoteDescription {
 extension SKNoteDescription: Codable {
     
     public enum CodingKeys: String, CodingKey {
-        case text, colour, code = "response_status_code"
+        case text, colour, code = "response_status_code", email, name
     }
     
 }

--- a/Sources/StampKit/SKResponse.swift
+++ b/Sources/StampKit/SKResponse.swift
@@ -12,6 +12,8 @@ import OSCKit
 public enum SKResponseKey: String {
     case text
     case colour
+    case email
+    case name
     case notes
 }
 
@@ -51,7 +53,9 @@ public final class SKResponse {
         } else if let note = message.arguments[0] as? String {
             noteText = note
         }
-        let string = SKPacket.jsonString(for: message.addressPattern(withApplication: true), data: .note(SKNoteDescription(text: noteText, colour: noteColour, code: code)))
+        let email: String? = dictionary?[SKResponseKey.email] as? String
+        let name: String? = dictionary?[SKResponseKey.name] as? String
+        let string = SKPacket.jsonString(for: message.addressPattern(withApplication: true), data: .note(SKNoteDescription(text: noteText, colour: noteColour, code: code, email: email, name: name)))
         let response = OSCMessage(with: message.responseAddress(), arguments: [string])
         response.readdress(to: response.addressPattern(withApplication: true))
         return response

--- a/Sources/StampKit/SKTimeline.swift
+++ b/Sources/StampKit/SKTimeline.swift
@@ -188,9 +188,16 @@ public final class SKTimeline: NSObject {
         })
     }
     
-    public func request(note: String, withColour colour: SKNoteColour, completionHandler: SKNoteHandler? = nil) {
+    public func request(note: String, withColour colour: SKNoteColour, email: String? = nil, name: String? = nil, completionHandler: SKNoteHandler? = nil) {
+        var arguments = [note, colour.rawValue]
+        if let email = email {
+            arguments.append(email)
+        }
+        if let name = name {
+            arguments.append(name)
+        }
         os_log("Sending Note: %{PUBLIC}@", log: .timeline, type: .info, note)
-        client.sendMessage(with: SKAddressParts.note.rawValue, arguments: [note, colour.rawValue], completionHandler: { data in
+        client.sendMessage(with: SKAddressParts.note.rawValue, arguments: arguments, completionHandler: { data in
             guard case .note(let description) = data else { return }
             guard let completion = completionHandler else { return }
             os_log("Receiving Note Reply: %{PUBLIC}@", log: .timeline, type: .info, description.text)


### PR DESCRIPTION
As a user I would like my notes to be associated with me so that when I'm looking over the timeline with my colleagues I can see which notes are from who.